### PR TITLE
Refactor graph helpers into modular graph package

### DIFF
--- a/src/graph/math.js
+++ b/src/graph/math.js
@@ -1,0 +1,47 @@
+import { topoSort } from "./topology.js";
+
+/**
+ * Propagate values across the DAG according to the provided SCM model.
+ *
+ * @param {Map<string, { parents: Record<string, number>, constant: number }>} model - Parsed SCM model.
+ * @param {Map<string, Set<string>>} eqs - Dependency map derived from the model.
+ * @param {Record<string, number>} currentValues - Current node values before propagation.
+ * @param {Record<string, boolean>} clampMap - Nodes that should remain fixed.
+ * @returns {Record<string, number>} A new object with propagated values.
+ */
+export function computeValues(model, eqs, currentValues, clampMap = {}) {
+  const order = topoSort(eqs);
+  const next = { ...currentValues };
+
+  for (const node of order) {
+    if (clampMap[node]) continue;
+    const spec = model.get(node) || { parents: {}, constant: 0 };
+    let sum = 0;
+    for (const [parent, coefficient] of Object.entries(spec.parents)) {
+      sum += coefficient * (next[parent] ?? 0);
+    }
+    next[node] = spec.constant + sum;
+  }
+
+  return next;
+}
+
+/**
+ * Shallow object equality helper used for value comparisons in React state.
+ *
+ * @template T extends Record<string, unknown>
+ * @param {T} a
+ * @param {T} b
+ * @returns {boolean} True when both objects contain the same key/value pairs.
+ */
+export function shallowEqualObj(a, b) {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  for (const key of keysA) {
+    if (a[key] !== b[key]) return false;
+  }
+  return true;
+}

--- a/src/graph/parser.js
+++ b/src/graph/parser.js
@@ -1,0 +1,84 @@
+/**
+ * Parse a textual structural causal model (SCM) specification into
+ * coefficient maps keyed by variable name.
+ *
+ * The parser accepts assignments separated by new lines or semicolons. Each
+ * right-hand side may include constants, `error`, and linear terms such as
+ * `0.5*A`. Variables that appear only as parents are automatically hoisted into
+ * the returned model with empty parent lists so that downstream code can
+ * assume every symbol has an entry.
+ *
+ * @param {string} text - Raw SCM specification provided by the user.
+ * @returns {{
+ *   model: Map<string, { parents: Record<string, number>, constant: number }>,
+ *   allVars: Set<string>
+ * }} Parsed coefficients organised by variable.
+ * @throws {Error} If a line cannot be parsed or contains duplicate variables.
+ */
+export function parseSCM(text) {
+  const lines = String(text || "")
+    .split(/[;\n]/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const model = new Map();
+  const allVars = new Set();
+
+  for (const line of lines) {
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+)$/);
+    if (!match) {
+      throw new Error(`Cannot parse: "${line}"`);
+    }
+
+    const child = match[1];
+    const rhs = match[2];
+    const normalised = rhs.replace(/-/g, "+ -");
+    const terms = normalised
+      .split("+")
+      .map((term) => term.trim())
+      .filter(Boolean);
+
+    const parents = {};
+    let constant = 0;
+
+    for (const term of terms) {
+      if (/^error$/i.test(term)) continue;
+
+      if (/^[+-]?\d*\.?\d+(e[+-]?\d+)?$/i.test(term)) {
+        constant += parseFloat(term);
+        continue;
+      }
+
+      const star = term.indexOf("*");
+      let coefficient = 1;
+      let variable = term;
+
+      if (star !== -1) {
+        coefficient = parseFloat(term.slice(0, star));
+        variable = term.slice(star + 1).trim();
+      }
+
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(variable)) {
+        throw new Error(`Unsupported term: "${term}" in line "${line}"`);
+      }
+
+      parents[variable] = (parents[variable] ?? 0) + (Number.isNaN(coefficient) ? 1 : coefficient);
+    }
+
+    if (model.has(child)) {
+      throw new Error(`Duplicate definition for ${child}`);
+    }
+
+    model.set(child, { parents, constant });
+    allVars.add(child);
+    Object.keys(parents).forEach((parent) => allVars.add(parent));
+  }
+
+  for (const variable of allVars) {
+    if (!model.has(variable)) {
+      model.set(variable, { parents: {}, constant: 0 });
+    }
+  }
+
+  return { model, allVars };
+}

--- a/src/graph/topology.js
+++ b/src/graph/topology.js
@@ -1,0 +1,62 @@
+/**
+ * Convert an SCM model map into adjacency information where each node points
+ * to the set of its direct parent variables.
+ *
+ * @param {Map<string, { parents: Record<string, number> }>} model - Parsed SCM model.
+ * @returns {Map<string, Set<string>>} A map of variable -> set of parent variables.
+ */
+export function depsFromModel(model) {
+  const eqs = new Map();
+  if (!model) return eqs;
+
+  for (const [child, spec] of model) {
+    const parentKeys = spec?.parents ? Object.keys(spec.parents) : [];
+    eqs.set(child, new Set(parentKeys));
+  }
+
+  return eqs;
+}
+
+/**
+ * Perform a topological sort on a dependency map.
+ *
+ * @param {Map<string, Set<string>>} eqs - Dependency map created by {@link depsFromModel}.
+ * @returns {string[]} Nodes ordered from sources to sinks.
+ * @throws {Error} If the graph contains a cycle.
+ */
+export function topoSort(eqs) {
+  const graph = eqs ?? new Map();
+  const nodeIds = [...graph.keys()];
+  const indegrees = new Map(nodeIds.map((node) => [node, 0]));
+
+  for (const [child, parents] of graph) {
+    for (const parent of parents) {
+      indegrees.set(child, (indegrees.get(child) || 0) + 1);
+      if (!indegrees.has(parent)) {
+        indegrees.set(parent, indegrees.get(parent) || 0);
+      }
+    }
+  }
+
+  const queue = nodeIds.filter((node) => (indegrees.get(node) || 0) === 0);
+  const order = [];
+
+  while (queue.length) {
+    const node = queue.shift();
+    order.push(node);
+
+    for (const [child, parents] of graph) {
+      if (!parents.has(node)) continue;
+      indegrees.set(child, indegrees.get(child) - 1);
+      if (indegrees.get(child) === 0) {
+        queue.push(child);
+      }
+    }
+  }
+
+  if (order.length !== indegrees.size) {
+    throw new Error("SCM contains a cycle (not a DAG).");
+  }
+
+  return order;
+}

--- a/tests/graph/math.test.js
+++ b/tests/graph/math.test.js
@@ -1,0 +1,41 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { computeValues } from "../../src/graph/math.js";
+import { depsFromModel } from "../../src/graph/topology.js";
+
+const MODEL = new Map([
+  ["U", { parents: {}, constant: 2 }],
+  ["X", { parents: { U: 0.5 }, constant: 1 }],
+  ["Y", { parents: { X: 2 }, constant: -1 }],
+]);
+
+const EQS = depsFromModel(MODEL);
+
+test("computeValues propagates values in topological order", () => {
+  const current = { U: 4 };
+  const clamp = {};
+  const next = computeValues(MODEL, EQS, current, clamp);
+
+  // U is recalculated from its constant (2)
+  assert.equal(next.U, 2);
+  // X should see U's updated value rather than the initial 4
+  assert.equal(next.X, 1 + 0.5 * next.U);
+  assert.equal(next.Y, -1 + 2 * next.X);
+});
+
+test("computeValues respects clamped nodes", () => {
+  const current = { U: 4, X: 99, Y: 123 };
+  const clamp = { X: true };
+  const next = computeValues(MODEL, EQS, current, clamp);
+
+  assert.equal(next.X, 99);
+  assert.equal(next.Y, -1 + 2 * next.X);
+});
+
+test("computeValues returns a new object", () => {
+  const current = { U: 1, X: 2, Y: 3 };
+  const clamp = {};
+  const result = computeValues(MODEL, EQS, current, clamp);
+
+  assert.notStrictEqual(result, current);
+});

--- a/tests/graph/parser.test.js
+++ b/tests/graph/parser.test.js
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseSCM } from "../../src/graph/parser.js";
+
+const SAMPLE_SCM = `
+Y = 2*X + 3 + error
+X = error
+`;
+
+test("parseSCM extracts coefficients and constants", () => {
+  const { model, allVars } = parseSCM(SAMPLE_SCM);
+
+  assert.ok(model instanceof Map);
+  assert.deepEqual([...allVars].sort(), ["X", "Y"]);
+
+  const ySpec = model.get("Y");
+  assert.deepEqual(ySpec.parents, { X: 2 });
+  assert.equal(ySpec.constant, 3);
+
+  const xSpec = model.get("X");
+  assert.deepEqual(xSpec.parents, {});
+  assert.equal(xSpec.constant, 0);
+});
+
+test("parseSCM throws for malformed lines", () => {
+  assert.throws(() => parseSCM("not-valid"), /Cannot parse/);
+});
+
+test("parseSCM prevents duplicate declarations", () => {
+  const duplicate = "A = 1\nA = 2";
+  assert.throws(() => parseSCM(duplicate), /Duplicate/);
+});

--- a/tests/graph/topology.test.js
+++ b/tests/graph/topology.test.js
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { depsFromModel, topoSort } from "../../src/graph/topology.js";
+
+const MODEL = new Map([
+  ["A", { parents: {}, constant: 0 }],
+  ["B", { parents: { A: 1 }, constant: 0 }],
+  ["C", { parents: { B: 1 }, constant: 0 }],
+]);
+
+test("depsFromModel builds parent sets", () => {
+  const eqs = depsFromModel(MODEL);
+  assert.ok(eqs instanceof Map);
+  assert.deepEqual(eqs.get("A"), new Set());
+  assert.deepEqual(eqs.get("B"), new Set(["A"]));
+});
+
+test("topoSort returns parents before children", () => {
+  const eqs = depsFromModel(MODEL);
+  const order = topoSort(eqs);
+  assert.deepEqual(order, ["A", "B", "C"]);
+});
+
+test("topoSort throws on cycles", () => {
+  const cyclic = new Map([
+    ["A", new Set(["C"])],
+    ["B", new Set(["A"])],
+    ["C", new Set(["B"])],
+  ]);
+
+  assert.throws(() => topoSort(cyclic), /cycle/i);
+});


### PR DESCRIPTION
Summary
What changed
- Extracted SCM parsing, dependency mapping, and propagation utilities into `src/graph/` modules with documentation.
- Updated the React app to consume the new helpers and keep layout/value logic identical.
- Added focused unit tests for parsing edge cases, cycle detection, and value propagation.
Why it matters
- Centralises graph math in pure, reusable utilities that can be tested in isolation.
- Provides targeted coverage for DAG behaviours so refactors can be made safely.
How to use it (if user-visible)
- No UI changes; the app runs exactly as before.

Changes
- src/App.jsx: Import shared graph helpers instead of defining them inline.
- src/graph/parser.js: New parser module with JSDoc-documented `parseSCM`.
- src/graph/topology.js: New topology helpers for building dependency sets and topo sort.
- src/graph/math.js: New propagation utilities including `computeValues` and `shallowEqualObj`.
- tests/graph/*.test.js: Added parser, topology, and math unit tests.

Behavior
Before: Graph parsing/topology/value logic lived inside the React component without dedicated tests.
After: Logic is supplied by pure modules with focused unit tests; runtime behaviour is unchanged.

Testing
Unit tests added/updated: `npm test`
Manual verification steps:
- npm run dev
- Navigate to the DAG editor
- Drag a slider and confirm values propagate and reset on release unless clamped
- Toggle marching-ants sources to ensure animation remains active

Regression Guard
- Seeded propagation intact (logic reused via extracted helpers).
- Immediate source updates intact (no change to React handlers).
- Marching-ants animation intact (edge utilities untouched).
- Ephemeral clamp & auto-unclamp intact (slider logic unchanged).


------
https://chatgpt.com/codex/tasks/task_e_68f528ddf9cc833388f45bae6f11340d