### PR TITLE
Centralize SCM presets and document structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@
 ## Project status
 Causion is under active development. The focus is stability of the four core behaviors above while we expand testing and quality‑of‑life features.
 
+## Directory structure (quick tour)
+Once the app is installed you will see these key folders:
+
+- `src/` – all source code for the React app.
+  - `src/App.jsx` – entry UI that wires together the panels and canvas.
+  - `src/components/` – reusable UI pieces such as panels, nodes, and edges.
+  - `src/data/presets.js` – shared SCM preset strings and helper math utilities (e.g., the triangular autoplay waveform).
+  - `src/graph/` – parsing and math helpers for structural causal models.
+  - `src/hooks/` – React hooks that manage state, propagation, and graph coordination.
+  - `src/utils/` – browser-friendly utilities (timers, formatting, etc.).
+- `tests/` – Node-based unit tests that exercise parsers, hooks, and presets.
+
 ## Contributing
 Pull requests are welcome. Please preserve the core behaviors and include tests for UI changes where feasible.
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,9 +10,8 @@ import "reactflow/dist/style.css";
 import CircleNode from "./components/nodes/CircleNode.jsx";
 import CausalEdge from "./components/edges/CausalEdge.jsx";
 import DevPanel from "./components/panels/DevPanel.jsx";
-import {
-  DEFAULT_FEATURE_FLAGS,
-} from "./components/constants.js";
+import { DEFAULT_FEATURE_FLAGS } from "./components/constants.js";
+import { PRESETS } from "./data/presets.js";
 import { useScmModel } from "./hooks/useScmModel.js";
 import { useNodeGraph } from "./hooks/useNodeGraph.js";
 import { usePropagationEffects } from "./hooks/usePropagationEffects.js";
@@ -21,10 +20,6 @@ const defaultFeatures = { ...DEFAULT_FEATURE_FLAGS };
 
 const nodeTypes = { circle: CircleNode };
 const edgeTypes = { causal: CausalEdge };
-
-const PRESET_1 = `Med = 0.5*A\nB = 0.5*Med`;
-const PRESET_2 = `A = 0.5*Con\nB = 0.5*Con`;
-const PRESET_3 = `Col = 0.5*A + 0.5*B`;
 
 function App() {
   return (
@@ -38,7 +33,8 @@ function CoreApp() {
   const reactFlow = useReactFlow();
   const [features, setFeatures] = useState(defaultFeatures);
 
-  const { scmText, setScmText, error, model, eqs, allVars, graphSignature } = useScmModel(PRESET_1);
+  const defaultPreset = PRESETS[0]?.text ?? "";
+  const { scmText, setScmText, error, model, eqs, allVars, graphSignature } = useScmModel(defaultPreset);
 
   const propagation = usePropagationEffects({
     model,
@@ -79,15 +75,15 @@ function CoreApp() {
         <div className="rounded-2xl shadow p-4 border">
           <div className="text-lg font-bold mb-2">SCM</div>
           <div className="flex gap-2 mb-2">
-            <button className="px-3 py-1 rounded-lg border" onClick={() => setScmText(PRESET_1)}>
-              Load Mediation
-            </button>
-            <button className="px-3 py-1 rounded-lg border" onClick={() => setScmText(PRESET_2)}>
-              Load Confounding
-            </button>
-            <button className="px-3 py-1 rounded-lg border" onClick={() => setScmText(PRESET_3)}>
-              Load Collider
-            </button>
+            {PRESETS.map((preset) => (
+              <button
+                key={preset.key}
+                className="px-3 py-1 rounded-lg border"
+                onClick={() => setScmText(preset.text)}
+              >
+                {preset.label}
+              </button>
+            ))}
           </div>
           <textarea
             className="w-full h-48 p-2 rounded-xl border"

--- a/src/data/presets.js
+++ b/src/data/presets.js
@@ -1,0 +1,23 @@
+// Preset SCM definitions and helper math utilities used across the app.
+// Keeping these strings centralized lets us share them between UI panels
+// and tests while making it easier for beginners to discover available
+// examples.
+
+export const PRESET_MEDIATION = `Med = 0.5*A\nB = 0.5*Med`;
+export const PRESET_CONFOUNDING = `A = 0.5*Con\nB = 0.5*Con`;
+export const PRESET_COLLIDER = `Col = 0.5*A + 0.5*B`;
+
+export const PRESETS = [
+  { key: "mediation", label: "Load Mediation", text: PRESET_MEDIATION },
+  { key: "confounding", label: "Load Confounding", text: PRESET_CONFOUNDING },
+  { key: "collider", label: "Load Collider", text: PRESET_COLLIDER },
+];
+
+// Triangular waveform helper used for the autoplay feature. Accepts a phase
+// in the range [0, 1) and returns a value that rises from 0 to 1 then falls
+// back to 0, giving a smooth loop for slider animations.
+export function tri(phase) {
+  const p = Number.isFinite(phase) ? phase : 0;
+  const t = p - Math.floor(p);
+  return t < 0.5 ? t * 2 : 2 - t * 2;
+}

--- a/src/hooks/usePropagationEffects.js
+++ b/src/hooks/usePropagationEffects.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { computeValues, shallowEqualObj } from "../graph/math.js";
 import { scheduleEdgePulse, scheduleNodeDisplayUpdate, clearPendingTimers } from "../utils/timers.js";
+import { tri } from "../data/presets.js";
 
 const DEFAULT_RANGE = { min: -100, max: 100 };
 
@@ -8,11 +9,6 @@ function clampToRange(value, range) {
   const num = Number(value ?? 0);
   if (!Number.isFinite(num)) return range.min;
   return Math.min(range.max, Math.max(range.min, num));
-}
-
-function tri(p) {
-  const t = p - Math.floor(p);
-  return t < 0.5 ? t * 2 : 2 - t * 2;
 }
 
 function computePropagationPlan(seeds, parentToChildren, lag) {

--- a/tests/data/presets.test.js
+++ b/tests/data/presets.test.js
@@ -1,0 +1,20 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseSCM } from "../../src/graph/parser.js";
+import { PRESETS, tri } from "../../src/data/presets.js";
+
+test("all presets parse without throwing", () => {
+  for (const preset of PRESETS) {
+    assert.doesNotThrow(() => {
+      const { model, allVars } = parseSCM(preset.text);
+      assert.ok(model instanceof Map, "model should be a Map");
+      assert.ok(allVars.size > 0, "preset should declare at least one variable");
+    }, `preset ${preset.key} should parse`);
+  }
+});
+
+test("tri helper returns a symmetric waveform", () => {
+  const samples = [0, 0.25, 0.5, 0.75, 1.5];
+  const outputs = samples.map((phase) => tri(phase));
+  assert.deepEqual(outputs, [0, 0.5, 1, 0.5, 1]);
+});


### PR DESCRIPTION
Summary
- **What changed**: Extracted the three built-in SCM presets and helper math into a shared data module, updated the SCM panel to consume it dynamically, and added preset coverage tests alongside repo documentation updates.
- **Why it matters**: Centralizing presets keeps the UI, hooks, and tests in sync, improving discoverability for new contributors while preventing drift or parse regressions.
- **How to use it**: The SCM panel still shows the same three buttons, now sourced from the shared preset list so future additions automatically appear.

Changes
- `src/data/presets.js`: New module exporting preset strings, metadata, and the reusable `tri` helper.
- `src/App.jsx`: Imports the preset list and renders buttons by iterating over it while keeping the UI identical.
- `src/hooks/usePropagationEffects.js`: Reuses the shared `tri` helper instead of redefining it locally.
- `tests/data/presets.test.js`: Adds parsing smoke tests for every preset plus `tri` waveform coverage.
- `README.md`: Documents the updated project directory layout for quick onboarding.

Behavior
- Before: Presets and the triangular helper lived inline in components/hooks, making reuse and testing awkward.
- After: Presets live in a dedicated data module that drives both the UI buttons and new parser smoke tests.

Testing
- Unit tests added/updated: `npm test`
- Manual verification steps:
  1. `npm run dev`
  2. Navigate to the SCM panel and click each preset button to populate the textarea.
  3. Drag any slider and release to confirm it unclamps, verifying marching-ants animation still runs.

Regression Guard
- [x] Seeded propagation intact
- [x] Immediate source updates intact
- [x] Marching-ants intact
- [x] Ephemeral clamp & auto-unclamp intact


------
https://chatgpt.com/codex/tasks/task_e_68f53834f3408333a051bc3c1eb9a62d