### PR TITLE
Add propagation timing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "test": "vitest",
-    "test:ci": "vitest run --reporter=basic && node --test tests/data/presets.test.js tests/graph/math.test.js tests/graph/parser.test.js tests/graph/topology.test.js tests/hooks/usePropagationEffects.test.js tests/hooks/useNodeGraph.test.js tests/hooks/useScmModel.test.js tests/edgeUtils.test.js tests/graphSignature.test.js tests/nodeUtils.test.js tests/timers.test.js",
+    "test:ci": "vitest run --reporter=basic && node --test tests/data/presets.test.js tests/graph/math.test.js tests/graph/parser.test.js tests/graph/topology.test.js tests/hooks/usePropagationEffects.test.js tests/hooks/useNodeGraph.test.js tests/hooks/useScmModel.test.js tests/hooks/propagationTiming.test.js tests/edgeUtils.test.js tests/graphSignature.test.js tests/nodeUtils.test.js tests/timers.test.js",
     "test:watch": "vitest watch",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/tests/hooks/propagationTiming.test.js
+++ b/tests/hooks/propagationTiming.test.js
@@ -1,0 +1,188 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  scheduleNodeDisplayUpdate,
+  scheduleEdgePulse,
+  clearPendingTimers,
+} from "../../src/utils/timers.js";
+import { __TEST_ONLY__ as helpers } from "../../src/hooks/usePropagationEffects.js";
+
+const { computePropagationPlan, collectPropagationSeeds } = helpers;
+
+function makeGraph(entries) {
+  const map = new Map();
+  for (const [parent, children] of entries) {
+    map.set(parent, new Set(children));
+  }
+  return map;
+}
+
+test("deterministic lag scheduling uses consistent delays", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+
+  const parentToChildren = makeGraph([
+    ["A", ["B", "C"]],
+    ["B", ["D"]],
+    ["C", ["E"]],
+  ]);
+
+  const seeds = ["A"];
+  const plan = computePropagationPlan(seeds, parentToChildren, 25);
+  assert.deepEqual(plan, [
+    { node: "B", parent: "A", delay: 25 },
+    { node: "C", parent: "A", delay: 25 },
+    { node: "D", parent: "B", delay: 50 },
+    { node: "E", parent: "C", delay: 50 },
+  ]);
+
+  const nodeTimers = new Map();
+  const pending = [];
+  const fired = [];
+
+  for (const step of plan) {
+    scheduleNodeDisplayUpdate(
+      nodeTimers,
+      pending,
+      step.node,
+      step.delay,
+      () => fired.push(step.delay)
+    );
+  }
+
+  assert.equal(nodeTimers.size, 4);
+  assert.equal(pending.length, 4);
+
+  t.mock.timers.tick(25);
+  assert.deepEqual(fired, [25, 25]);
+
+  t.mock.timers.tick(25);
+  assert.deepEqual(fired, [25, 25, 50, 50]);
+
+  t.mock.timers.reset();
+});
+
+test("seeded nodes commit immediately before timers fire", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+
+  const parentToChildren = makeGraph([["A", ["B"]]]);
+  const values = { A: 3, B: 9 };
+  const display = { A: 0, B: 0 };
+
+  const seeds = collectPropagationSeeds({
+    changedIds: ["A"],
+    directChanged: { A: true },
+    interventions: {},
+    autoPlay: {},
+    dragging: { A: false },
+    features: { ephemeralClamp: false },
+  });
+
+  seeds.forEach((id) => {
+    display[id] = values[id];
+  });
+
+  const plan = computePropagationPlan(seeds, parentToChildren, 40);
+  const nodeTimers = new Map();
+  const pending = [];
+
+  for (const step of plan) {
+    scheduleNodeDisplayUpdate(
+      nodeTimers,
+      pending,
+      step.node,
+      step.delay,
+      () => {
+        display[step.node] = values[step.node];
+      }
+    );
+  }
+
+  assert.equal(display.A, 3);
+  assert.equal(display.B, 0);
+
+  t.mock.timers.tick(40);
+  assert.equal(display.B, 9);
+
+  t.mock.timers.reset();
+});
+
+test("propagation plan avoids cycles and keeps earliest path", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+
+  const parentToChildren = makeGraph([
+    ["A", ["B"]],
+    ["B", ["A", "C"]],
+    ["X", ["C"]],
+  ]);
+
+  const plan = computePropagationPlan(["A", "X"], parentToChildren, 10);
+
+  assert.deepEqual(plan, [
+    { node: "B", parent: "A", delay: 10 },
+    { node: "C", parent: "X", delay: 10 },
+  ]);
+
+  const nodeTimers = new Map();
+  const pending = [];
+  const fired = [];
+
+  for (const step of plan) {
+    scheduleNodeDisplayUpdate(
+      nodeTimers,
+      pending,
+      step.node,
+      step.delay,
+      () => fired.push(step.parent)
+    );
+  }
+
+  t.mock.timers.tick(10);
+  assert.deepEqual(fired, ["A", "X"]);
+
+  t.mock.timers.tick(10);
+  assert.deepEqual(fired, ["A", "X"]);
+
+  t.mock.timers.reset();
+});
+
+test("clearPendingTimers cancels node and edge schedules", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+
+  const nodeTimers = new Map();
+  const edgeTimers = new Map();
+  const pending = [];
+  let edgeState = {};
+
+  scheduleNodeDisplayUpdate(
+    nodeTimers,
+    pending,
+    "B",
+    100,
+    () => {
+      throw new Error("node timer should be cleared");
+    }
+  );
+
+  scheduleEdgePulse(
+    edgeTimers,
+    pending,
+    "A->B",
+    40,
+    50,
+    (updater) => {
+      edgeState = typeof updater === "function" ? updater(edgeState) : updater;
+      return edgeState;
+    }
+  );
+
+  clearPendingTimers(pending, nodeTimers, edgeTimers);
+
+  assert.equal(pending.length, 0);
+  assert.equal(nodeTimers.size, 0);
+  assert.equal(edgeTimers.size, 0);
+
+  t.mock.timers.tick(200);
+  assert.deepEqual(edgeState, {});
+
+  t.mock.timers.reset();
+});


### PR DESCRIPTION
## Summary
- add a dedicated propagation timing test suite covering lag scheduling, immediate commits, cycles, and cleanup
- reuse the existing timer helpers and hook internals to validate deterministic seeded propagation
- wire the new suite into the CI node-test command so it runs automatically

## What changed
- new node:test file `tests/hooks/propagationTiming.test.js`
- updated `package.json` test:ci script

## Why it matters
- guards the deterministic seeded lag propagation contract and edge timer cleanup behavior

## How to use it (if user-visible)
- no user-facing changes; run `node --test tests/hooks/propagationTiming.test.js` to execute the new tests

## Changes
- `tests/hooks/propagationTiming.test.js`: propagation scheduling, cycle prevention, and timer cleanup specs
- `package.json`: include the new suite in `npm run test:ci`

## Behavior
- Before: no direct tests covering deterministic propagation timing and timer reset edge cases
- After: propagation timing behavior is enforced with deterministic fake-timer tests

## Testing
- Unit tests added/updated: `node --test tests/hooks/propagationTiming.test.js`
- Manual verification steps: not run (test-only change)

## Regression Guard
- [x] Seeded propagation intact
- [x] Immediate source updates intact
- [x] Marching-ants intact
- [x] Ephemeral clamp & auto-unclamp intact

## Follow-ups
- none


------
https://chatgpt.com/codex/tasks/task_e_68f54a42b5788333927777272b6a7c88