### PR TITLE
docs: add testing guide and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,14 @@ Follow these beginner-friendly steps to try the app on your computer:
 7. **Open the app in your browser** by typing that address into Chrome, Edge, or Firefox. You should now see the DAG simulation and can experiment with the sliders and nodes.
 8. **Stop the app** when you are done by returning to the terminal window and pressing `Ctrl + C` (or `Cmd + C` on macOS).
 
+## Testing
+Curious how we keep the four core behaviors stable? Read the detailed [Testing Guide](docs/testing.md) for background, folder layout, and invariant expectations. When you are ready to run the suites yourself:
+
+- `npm test` – runs the full Vitest suite once (the same command used in CI).
+- `npm run test:watch` – reruns tests automatically as you edit files.
+- `npm run test:ci` – alternate entry point for automated pipelines when defined.
+
+Invariant-focused checks (such as the slider clamp flow) live alongside our integration specs—for example, see `tests/integration/SliderClamp.test.js`.
+
 ## License
 TBD.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,35 @@
+# Testing Guide
+
+This document explains how to run the automated test suites for the Causion app, how the test files are organized, and which invariants every contributor must verify before shipping changes.
+
+## Test runners & commands
+
+We use **Vitest** together with **@testing-library/react**. All commands below should be run from the repository root after installing dependencies with `npm install`.
+
+- `npm test` – Executes the full Vitest suite once in watchless (CI-friendly) mode.
+- `npm run test:watch` – Starts Vitest in watch mode so tests rerun automatically as you edit files.
+- `npm run test:ci` – Alias for the CI configuration (if defined) that runs the same suite as `npm test`.
+
+> Tip for beginners: You can stop any command by pressing `Ctrl + C` (`Cmd + C` on macOS) in the terminal window.
+
+## Folder layout
+
+Test files live in the top-level `tests/` directory. Within that folder we group specs by scope so it’s easy to find the right place for new coverage:
+
+- `tests/components/` – Component-level tests that render individual React components with React Testing Library.
+- `tests/integration/` – Broader flows that combine multiple components or simulate user interactions.
+- `tests/utils/` – Pure function and helper utilities.
+- `tests/fixtures/` – Reusable mock data or helper factories shared across suites.
+
+If you are adding a new file and aren’t sure where it belongs, pick the folder whose description matches your test’s goal and mirror the existing naming style.
+
+## Required invariant checks
+
+Every change must preserve the four core behaviors that define the Causion experience. Whether you are adding code or updating documentation, run through this checklist (manually or via automated tests where applicable):
+
+1. **Seeded causal lag propagation** still produces deterministic, reproducible animation timing.
+2. **Immediate source updates** keep dependent nodes in sync as soon as a source node changes.
+3. **Marching-ants edge animation** remains visible and responsive on causal links.
+4. **Ephemeral clamp behavior** ensures that dragging a slider clamps temporarily, and releasing it resets the value unless “Clamp (do)” is enabled.
+
+Document in your pull request how you verified these invariants—via automated coverage, manual testing, or both.


### PR DESCRIPTION
Summary
- Document the available test commands and invariant expectations in a dedicated testing guide.
- Link the README testing section to the guide so newcomers can find commands quickly.
- Highlight where the invariant-focused suites live for easy discovery.

Changes
- docs/testing.md: Added runner overview, folder layout, and invariant checklist.
- README.md: Added testing section with commands and pointer to integration suites.

Behavior
Before: Testing commands and invariant expectations were scattered and undocumented.
After: Contributors have a single guide and README entry outlining commands and invariant coverage locations.

Testing
Unit tests added/updated: None (documentation-only change).
Manual verification steps:
- Not applicable (docs only).

Regression Guard
- Seeded propagation intact
- Immediate source updates intact
- Marching-ants intact
- Ephemeral clamp & auto-unclamp intact


------
https://chatgpt.com/codex/tasks/task_e_68f54ef973f08333bfdc14d82c02c98e